### PR TITLE
Fixing PWF2INT's corruptions at creating INTs

### DIFF
--- a/execs/sources/pwf2int/lzss.c
+++ b/execs/sources/pwf2int/lzss.c
@@ -151,6 +151,7 @@ static int encode(struct lzss_t *state, int EJ, const uint8_t *src, int srclen, 
       codebuf[0] |= mask;
       codebuf[codebufind++] = textbuf[r];
     } else {
+      codebuf[codebufind++] = (uint8_t)(matchpos);
       codebuf[codebufind++] = (uint8_t)(
 	((matchpos >> (8 - EJ)) & ~((1 << EJ)-1)) |
         (matchlen - (THRESHOLD + 1))

--- a/execs/sources/pwf2int/pwf2int.cpp
+++ b/execs/sources/pwf2int/pwf2int.cpp
@@ -142,7 +142,7 @@ intsection_offset_table_t get_int_section_offsets(std::vector<intfile_t> &intfil
         fnsize += intfile.filename.length() + 1;
     }
     r.lzss = ALIGN(r.characters + fnsize, 0x800);
-    r.end = ALIGN((r.lzss + lzss_size), 0x800);
+    r.end = ALIGN((r.lzss + lzss_size) + sizeof(pwf2int::lzss_header_t), 0x800);
     return r;
 }
 


### PR DESCRIPTION
This pull request fixes 2 issues on the PWF2INT tool:
- A issue caused by a removal of a line on lzss.c in 14.5 that corrupted the entire INT after creating it from a folder
- The alignment function didn't calculated the LZSS header, causing rare instances where data from files would be overwriten by the next section, making some files corrupt the last file on the section and freeze the game (more commonly seen in stage 2's INT)

I tested the changes on all the files in DATA and DATAS folder in the retail USA version.